### PR TITLE
Update to latest ExampleNFT

### DIFF
--- a/initialize-account/initialize-account.cdc.tmpl
+++ b/initialize-account/initialize-account.cdc.tmpl
@@ -1,6 +1,3 @@
-import NFTStorefront from ${NFTStorefrontContractAddress}
-import DapperUtilityCoin from ${DapperUtilityCoinContractAddress}
-import FungibleToken from ${FungibleTokenContractAddress}
 import ${NFTContractName} from ${NFTContractAddress}
 
 // This transcation initializes an account with a collection that allows it to hold NFTs from a specific contract. It will
@@ -10,7 +7,7 @@ transaction {
         if collector.borrow<&${NFTContractName}.Collection>(from: ${NFTContractName}.CollectionStoragePath) == nil {
             let collection <- ${NFTContractName}.createEmptyCollection() as! @${NFTContractName}.Collection
             collector.save(<-collection, to: ${NFTContractName}.CollectionStoragePath)
-            collector.link<&{${NFTContractName}.CollectionPublic}>(
+            collector.link<&{${NFTContractName}.${NFTContractName}CollectionPublic}>(
                 ${NFTContractName}.CollectionPublicPath,
                 target: ${NFTContractName}.CollectionStoragePath,
             )


### PR DESCRIPTION
based on this file https://github.com/onflow/flow-nft/blob/master/contracts/ExampleNFT.cdc it was necessary to make the above edit.

Otherwise I get the following error based on testnet.env config value NFTContractName=UFC_FIGHTER_NFT

    thrown: "execution error code 1101: [Error Code: 1101] cadence runtime error Execution failed:
    error: cannot find type in this scope: `UFC_FIGHTER_NFT.CollectionPublic`
      --> 5475b9baf61c442179fba452771c410d413477d2b66d43cefb993492625a6864:10:29
       |
    10 |             collector.link<&{UFC_FIGHTER_NFT.CollectionPublic}>(
       |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

    error: ambiguous restricted type
      --> 5475b9baf61c442179fba452771c410d413477d2b66d43cefb993492625a6864:10:28
       |
    10 |             collector.link<&{UFC_FIGHTER_NFT.CollectionPublic}>(
       |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    error: cannot infer type parameter: `T`
      --> 5475b9baf61c442179fba452771c410d413477d2b66d43cefb993492625a6864:10:12
       |
    10 |             collector.link<&{UFC_FIGHTER_NFT.CollectionPublic}>(
       |             ^
    "
