### PR TITLE
Minor edit to avoid whitespace error

### DIFF
--- a/create-listing/create-listing.cdc.tmpl
+++ b/create-listing/create-listing.cdc.tmpl
@@ -33,10 +33,9 @@ transaction(saleItemID: UInt64, saleItemPrice: UFix64, royaltyPercent: UFix64) {
 
         // If the user does not have their collection linked to their account, link it.
         let nftProviderPrivatePath = /private/${NFTContractName}CollectionProviderForNFTStorefront
-        let hasLinkedCollection = seller.
-            getCapability<&${NFTContractName}.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(
-                nftProviderPrivatePath
-            )!.check()
+        let hasLinkedCollection = seller.getCapability<&${NFTContractName}.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(
+            nftProviderPrivatePath
+        )!.check()
         if !hasLinkedCollection {
             seller.link<&${NFTContractName}.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(
                 nftProviderPrivatePath,
@@ -45,10 +44,9 @@ transaction(saleItemID: UInt64, saleItemPrice: UFix64, royaltyPercent: UFix64) {
         }
 
         // Get a capability to access the user's NFT collection.
-        self.nftProvider = seller.
-            getCapability<&${NFTContractName}.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(
-                nftProviderPrivatePath
-            )!
+        self.nftProvider = seller.getCapability<&${NFTContractName}.Collection{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(
+            nftProviderPrivatePath
+        )!
         assert(self.nftProvider.borrow() != nil, message: "Missing or mis-typed collection provider")
 
         // Get a reference to the user's NFT storefront


### PR DESCRIPTION
When used as was receiving an error:

`
  console.log
    Error: failed to parse transaction Cadence script: Parsing failed:
    error: invalid whitespace after '.'
      --> :36:41
       |
    36 |         let hasLinkedCollection = seller.
       |                                          ^
    
    error: invalid whitespace after '.'
      --> :48:34
       |
    48 |         self.nftProvider = seller.
       |                                   ^
`