### PR TITLE
Remove hard code 2

### DIFF
--- a/purchase-pack-direct/mainnet.env
+++ b/purchase-pack-direct/mainnet.env
@@ -2,6 +2,6 @@ FungibleTokenContractAddress=0xf233dcee88fe0abe
 NonFungibleTokenContractAddress=0x1d7e57aa55817448
 DapperUtilityCoinContractAddress=0xead892083b3e2c6c
 NFTStorefrontContractAddress=0x4eb8a10cb9f87357
-PackNFTAddress=
+PackNFTContractAddress=
 NFTContractName=
 NFTContractAddress=

--- a/purchase-pack-direct/purchase-pack-direct.cdc.tmpl
+++ b/purchase-pack-direct/purchase-pack-direct.cdc.tmpl
@@ -23,7 +23,7 @@ transaction(storefrontAddress: Address, listingResourceID: UInt64, expectedPrice
         // Initialize the collection if the buyer does not already have one
         if buyer.borrow<&${NFTContractName}.Collection>(from: ${NFTContractName}.CollectionStoragePath) == nil {
             buyer.save(<-${NFTContractName}.createEmptyCollection(), to: ${NFTContractName}.CollectionStoragePath
-            buyer.link<&${NFTContractName}.Collection{NonFungibleToken.CollectionPublic, ${NFTContractName}.MomentNFTCollectionPublic}>(
+            buyer.link<&${NFTContractName}.Collection{NonFungibleToken.CollectionPublic, ${NFTContractName}.${NFTContractName}CollectionPublic}>(
                 ${NFTContractName}.CollectionPublicPath,
                 target: ${NFTContractName}.CollectionStoragePath
             )

--- a/purchase-pack-direct/purchase-pack-direct.cdc.tmpl
+++ b/purchase-pack-direct/purchase-pack-direct.cdc.tmpl
@@ -1,7 +1,7 @@
 import FungibleToken from ${FungibleTokenContractAddress}
 import NonFungibleToken from ${NonFungibleTokenContractAddress}
 import NFTStorefront from ${NFTStorefrontContractAddress}
-import PackNFT from ${PackNFTAddress}
+import PackNFT from ${PackNFTContractAddress}
 import DapperUtilityCoin from ${DapperUtilityCoinContractAddress}
 import ${NFTContractName} from ${NFTContractAddress}
 

--- a/purchase-pack-direct/testnet.env
+++ b/purchase-pack-direct/testnet.env
@@ -2,6 +2,6 @@ FungibleTokenContractAddress=0x9a0766d93b6608b7
 NonFungibleTokenContractAddress=0x631e88ae7f1d7c20
 DapperUtilityCoinContractAddress=0x82ec283f88a62e65
 NFTStorefrontContractAddress=0x94b06cfca1d8a476
-PackNFTAddress=
+PackNFTContractAddress=
 NFTContractName=
 NFTContractAddress=


### PR DESCRIPTION
two minor edits

1) to remove hardcoded contract name MomentNFT 

2) To unify variable contract naming to support https://github.com/dapperlabs/dapper-supported-transactions/pull/8