### PR TITLE
Fix type error in get_metadata_from_storefront_listing.cdc

### DIFF
--- a/metadata_script/get_metadata_from_storefront_listing.cdc
+++ b/metadata_script/get_metadata_from_storefront_listing.cdc
@@ -9,7 +9,7 @@ pub struct PurchaseData {
     pub let description: String
     pub let imageURL: String
 
-    init(id: UInt64, name: String?, amount: UFix64, description: String?, imageURL: String?) {
+    init(id: UInt64, name: String, amount: UFix64, description: String, imageURL: String) {
         self.id = id
         self.name = name
         self.amount = amount


### PR DESCRIPTION
The struct contructor params were optional while the fields are required